### PR TITLE
Add support for pulling mysql:8.0 image compatible with M1 Macs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
 
   mysql:
     image: mysql:8.0
+    platform: linux/x86_64/v8
     ports:
       - 3306:3306
     environment:
@@ -53,3 +54,4 @@ networks:
   adjoe:
     name: adjoe-test
     driver: bridge
+


### PR DESCRIPTION
Verified working on
Mac Intel
Mac M1
Linux